### PR TITLE
Cambiar estilo de Calendario de Google

### DIFF
--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -24,15 +24,16 @@
         <section class="calendar-iframe my-8">
             <h2 class="text-center text-3xl font-semibold text-gray-800 dark:text-white">Eventos</h2>
 
-            <div class="flex justify-center mt-4">
+            <div class="flex justify-center mt-4 dark:invert">
                 <iframe 
-                        src="https://embed.styledcalendar.com/#fWYVcvwalx9ov1ub9JO4" 
-                        title="Styled Calendar" 
-                        class="styled-calendar-container" 
-                        style="width: 50%; border: none;" 
-                        data-cy="calendar-embed-iframe">
-                </iframe>                
-            <script async type="module" src="https://embed.styledcalendar.com/assets/parent-window.js"></script>
+                    src="https://calendar.google.com/calendar/embed?height=600&wkst=2&ctz=Europe%2FMadrid&bgcolor=%23ffffff&title=Club%20de%20Algoritmia%20de%20la%20Universidad%20de%20Sevilla&showPrint=0&showTabs=0&showCalendars=0&showTz=0&src=Y2x1YmFsZ29yaXRtaWF1c0BnbWFpbC5jb20&color=%238E24AA"
+                    style="border-width:0"
+                    width="900"
+                    height="600"
+                    frameborder="0"
+                    scrolling="no"
+                    >
+                </iframe>               
             </div>
         </section>
         


### PR DESCRIPTION
Debido a que Google Calendar ha cambiado su diseño de los iframes, se ha decidido eliminar los estilos que se añadieron mediante aplicaciones de terceros y usar el iframe puro de Google Calendar.

Como novedad, dependiendo de si es el modo oscuro o no, se cambiará el estilo del calendario