### PR TITLE
feat: Modificar el enlace de las diapositivas de las sesiones del CAUS

### DIFF
--- a/content/resources/training/index.md
+++ b/content/resources/training/index.md
@@ -18,8 +18,8 @@ Esta es nuestra sección. Aquí encontrarás todo el material que preparamos en 
 
 Si te perdiste una sesión de formación o simplemente quieres repasar un tema, este es tu sitio.
 
-*   **📎 Archivo de Sesiones del Club (CAUS 23/24 y 24/25):**
-    *   **[Accede aquí a la carpeta de Google Drive](https://drive.google.com/drive/folders/1HRhaTf-Dtha1T21ZTzjj7y-6WswkB9OP?usp=sharing)**
+*   **📎 Archivo de Sesiones del Club (últimos tres cursos):**
+    *   **[Accede aquí a la carpeta de Google Drive](https://drive.google.com/drive/folders/1uCZkV2LYut2omt07VdXgtjm6L0qgjgZR?usp=drive_link)**
     *   En esta carpeta encontrarás todo el material (diapositivas, código de ejemplo y soluciones) de las sesiones de formación que realizamos. Es el recurso perfecto para ponerte al día.
 
 #### Listas de problemas

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -190,7 +190,11 @@ menu:
       pre: /images/logos/feedback.svg
       name: Feedback (Sesiones)
       url: https://forms.gle/bP9Jc81q4Hes1ZoN6
-      weight: 70  
+      weight: 70
+    - identifier: archivo-sesiones
+      name: Archivo de Sesiones
+      url: https://drive.google.com/drive/folders/1HRhaTf-Dtha1T21ZTzjj7y-6WswkB9OP?usp=sharing
+      weight: 80  
     
     
   # dropdown:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -193,7 +193,7 @@ menu:
       weight: 70
     - identifier: archivo-sesiones
       name: Archivo de Sesiones
-      url: https://drive.google.com/drive/folders/1HRhaTf-Dtha1T21ZTzjj7y-6WswkB9OP?usp=sharing
+      url: https://drive.google.com/drive/folders/1uCZkV2LYut2omt07VdXgtjm6L0qgjgZR?usp=drive_link
       weight: 80  
     
     


### PR DESCRIPTION
En esta PR con el objetivo de que los miembros puedan encontrar las diapositivas de las diferentes sesiones se han realizado los siguientes cambios.

1. Se ha modificado el enlace que había en la sección de recursos con el actualizado (por la migración de carpetas)
2. Se ha añadido en la barra de navegación el enlace a Archivo de sesiones, para que sea más fácil de encontrar. Se pueden pensar otros nombres jajaja.

Todo el código ha sido probado :p 